### PR TITLE
Bug/deeply nested route support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@analogstudiosri/greenwood-plugin-font-awesome",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A Greenwood plugin for managing Font Awesome related dependencies for building and development.",
   "main": "src/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:tdd": "yarn test --watch"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.20.0-alpha.1",
+    "@greenwood/cli": "^0.20.0",
     "font-awesome": "^4.6.3"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+// import fs from 'fs';
 import path from 'path';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 import { getNodeModulesLocationForPackage } from '@greenwood/cli/src/lib/node-modules-utils.js';
@@ -19,7 +20,12 @@ class FontAwesomeResource extends ResourceInterface {
     const nodeModulesLocation = await getNodeModulesLocationForPackage('font-awesome');
     const barePath = this.getBareUrlPath(url);
 
-    return Promise.resolve(path.join(nodeModulesLocation, barePath));
+    console.debug({ nodeModulesLocation });
+    console.debug('FontAwesomeResource', url);
+    console.debug({ barePath });
+    // console.debug({ location });
+    console.debug('resolveRelativeUrl', this.resolveRelativeUrl(nodeModulesLocation, barePath));
+    return Promise.resolve(path.join(nodeModulesLocation, this.resolveRelativeUrl(nodeModulesLocation, barePath)));
   }
 }
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
As part of https://github.com/AnalogStudiosRI/www.analogstudios.net/pull/72, noticed that if I had a route like
`/albums/some-album-name`

Deeply nested paths and relative directories were causing issues, lead to file being loaded like
```sh
../albums/styles/theme.css
```

This can be solved in userland already but requires a conditionals
```js
const location = this.resolveRelativeUrl(nodeModulesLocation, barePath) || barePath;
```

But thought it might be nice to have Greenwood do this for us though so just going to wait for that, eg.
```
const location = this.resolveRelativeUrl(nodeModulesLocation, barePath)
```

## Summary of Changes
1. Leverage (unreleased) Greenwood feature that will just return a proper URL if it already exists at the current location, otherwise walk

## TODO
1. [ ] Wait for and upgrade when upstream is merged - 